### PR TITLE
Remove mogenius from deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ Fork The Repo
 ### Deploy Railway
 
 <a href="https://railway.app/new"><img title="Phoenix-MD Deploy Railway" src="https://img.shields.io/badge/DEPLOY RAILWAY-h?color=black&style=for-the-badge&logo=Railway"></a>
-
-### Deploy Mogenius
-
-<a href="https://studio.mogenius.com/studio/cloud-space/cloud-space-overview"><img title="Phoenix-MD Deploy Mogenius" src="https://img.shields.io/badge/DEPLOY MOGENIUS-h?color=black&style=for-the-badge&logo=genius"></a> 
  
  ## Support
 


### PR DESCRIPTION
Hi there, mogenius doesn't have free cloud resources anymore. It is possible to deploy the container for free but it requires a local Kubernetes. I suppose this is not a use case for this app so I suggest to remove mogenius from the deployment guide.